### PR TITLE
fix the problem with wrong linkConstructor value for Thomas edition

### DIFF
--- a/postColl-workspace/edit-distance/editionHeatMap.svg
+++ b/postColl-workspace/edit-distance/editionHeatMap.svg
@@ -41,7 +41,7 @@
          <!--LinkInfo VALUE: C02_app10_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_i/#C02_app10">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_i/#C02_app10">
                <line x1="600"
                      x2="600"
                      y1="30"
@@ -104,7 +104,7 @@
          <!--LinkInfo VALUE: C03_app12_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_ii/#C03_app12">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_ii/#C03_app12">
                <line x1="600"
                      x2="600"
                      y1="60"
@@ -167,7 +167,7 @@
          <!--LinkInfo VALUE: C03_app16_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_ii/#C03_app16">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_ii/#C03_app16">
                <line x1="600"
                      x2="600"
                      y1="90"
@@ -230,7 +230,7 @@
          <!--LinkInfo VALUE: C03_app17_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_ii/#C03_app17">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_ii/#C03_app17">
                <line x1="600"
                      x2="600"
                      y1="120"
@@ -293,7 +293,7 @@
          <!--LinkInfo VALUE: C03_app23_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_ii/#C03_app23">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_ii/#C03_app23">
                <line x1="600"
                      x2="600"
                      y1="150"
@@ -356,7 +356,7 @@
          <!--LinkInfo VALUE: C03_app39_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_ii/#C03_app39">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_ii/#C03_app39">
                <line x1="600"
                      x2="600"
                      y1="180"
@@ -419,7 +419,7 @@
          <!--LinkInfo VALUE: C04_app12_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iii/#C04_app12">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iii/#C04_app12">
                <line x1="600"
                      x2="600"
                      y1="210"
@@ -482,7 +482,7 @@
          <!--LinkInfo VALUE: C04_app25_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iii/#C04_app25">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iii/#C04_app25">
                <line x1="600"
                      x2="600"
                      y1="240"
@@ -545,7 +545,7 @@
          <!--LinkInfo VALUE: C04_app27_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iii/#C04_app27">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iii/#C04_app27">
                <line x1="600"
                      x2="600"
                      y1="270"
@@ -608,7 +608,7 @@
          <!--LinkInfo VALUE: C05_app10_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C05_app10">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C05_app10">
                <line x1="600"
                      x2="600"
                      y1="300"
@@ -671,7 +671,7 @@
          <!--LinkInfo VALUE: C05_app26_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C05_app26">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C05_app26">
                <line x1="600"
                      x2="600"
                      y1="330"
@@ -734,7 +734,7 @@
          <!--LinkInfo VALUE: C06_app7_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C06_app7">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C06_app7">
                <line x1="600"
                      x2="600"
                      y1="360"
@@ -797,7 +797,7 @@
          <!--LinkInfo VALUE: C06_app9_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C06_app9">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C06_app9">
                <line x1="600"
                      x2="600"
                      y1="390"
@@ -860,7 +860,7 @@
          <!--LinkInfo VALUE: C06_app10_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C06_app10">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C06_app10">
                <line x1="600"
                      x2="600"
                      y1="420"
@@ -923,7 +923,7 @@
          <!--LinkInfo VALUE: C06_app13_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C06_app13">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C06_app13">
                <line x1="600"
                      x2="600"
                      y1="450"
@@ -986,7 +986,7 @@
          <!--LinkInfo VALUE: C06_app19_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C06_app19">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C06_app19">
                <line x1="600"
                      x2="600"
                      y1="480"
@@ -1049,7 +1049,7 @@
          <!--LinkInfo VALUE: C06_app29_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C06_app29">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C06_app29">
                <line x1="600"
                      x2="600"
                      y1="510"
@@ -1112,7 +1112,7 @@
          <!--LinkInfo VALUE: C06_app38_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_letter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_letter_iv/#C06_app38">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_letter_iv/#C06_app38">
                <line x1="600"
                      x2="600"
                      y1="540"
@@ -1175,7 +1175,7 @@
          <!--LinkInfo VALUE: C07_app4_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C07_app4">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C07_app4">
                <line x1="600"
                      x2="600"
                      y1="570"
@@ -1238,7 +1238,7 @@
          <!--LinkInfo VALUE: C07_app28_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C07_app28">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C07_app28">
                <line x1="600"
                      x2="600"
                      y1="600"
@@ -1301,7 +1301,7 @@
          <!--LinkInfo VALUE: C07_app38_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C07_app38">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C07_app38">
                <line x1="600"
                      x2="600"
                      y1="630"
@@ -1375,7 +1375,7 @@
          <!--LinkInfo VALUE: C08_app2_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app2">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app2">
                <line x1="600"
                      x2="600"
                      y1="660"
@@ -1438,7 +1438,7 @@
          <!--LinkInfo VALUE: C08_app4_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app4">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app4">
                <line x1="600"
                      x2="600"
                      y1="690"
@@ -1501,7 +1501,7 @@
          <!--LinkInfo VALUE: C08_app7_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app7">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app7">
                <line x1="600"
                      x2="600"
                      y1="720"
@@ -1564,7 +1564,7 @@
          <!--LinkInfo VALUE: C08_app21_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app21">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app21">
                <line x1="600"
                      x2="600"
                      y1="750"
@@ -1638,7 +1638,7 @@
          <!--LinkInfo VALUE: C08_app52_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app52">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app52">
                <line x1="600"
                      x2="600"
                      y1="780"
@@ -1712,7 +1712,7 @@
          <!--LinkInfo VALUE: C08_app57_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app57">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app57">
                <line x1="600"
                      x2="600"
                      y1="810"
@@ -1786,7 +1786,7 @@
          <!--LinkInfo VALUE: C08_app59_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app59">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app59">
                <line x1="600"
                      x2="600"
                      y1="840"
@@ -1860,7 +1860,7 @@
          <!--LinkInfo VALUE: C08_app61_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app61">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app61">
                <line x1="600"
                      x2="600"
                      y1="870"
@@ -1934,7 +1934,7 @@
          <!--LinkInfo VALUE: C08_app73_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app73">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app73">
                <line x1="600"
                      x2="600"
                      y1="900"
@@ -2008,7 +2008,7 @@
          <!--LinkInfo VALUE: C08_app122_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app122">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app122">
                <line x1="600"
                      x2="600"
                      y1="930"
@@ -2082,7 +2082,7 @@
          <!--LinkInfo VALUE: C08_app163_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app163">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app163">
                <line x1="600"
                      x2="600"
                      y1="960"
@@ -2156,7 +2156,7 @@
          <!--LinkInfo VALUE: C08_app190_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app190">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app190">
                <line x1="600"
                      x2="600"
                      y1="990"
@@ -2230,7 +2230,7 @@
          <!--LinkInfo VALUE: C08_app211_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app211">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app211">
                <line x1="600"
                      x2="600"
                      y1="1020"
@@ -2293,7 +2293,7 @@
          <!--LinkInfo VALUE: C08_app213_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app213">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app213">
                <line x1="600"
                      x2="600"
                      y1="1050"
@@ -2367,7 +2367,7 @@
          <!--LinkInfo VALUE: C08_app262_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app262">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app262">
                <line x1="600"
                      x2="600"
                      y1="1080"
@@ -2430,7 +2430,7 @@
          <!--LinkInfo VALUE: C08_app267_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app267">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app267">
                <line x1="600"
                      x2="600"
                      y1="1110"
@@ -2493,7 +2493,7 @@
          <!--LinkInfo VALUE: C08_app278_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app278">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app278">
                <line x1="600"
                      x2="600"
                      y1="1140"
@@ -2567,7 +2567,7 @@
          <!--LinkInfo VALUE: C08_app310_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app310">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app310">
                <line x1="600"
                      x2="600"
                      y1="1170"
@@ -2630,7 +2630,7 @@
          <!--LinkInfo VALUE: C08_app360_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app360">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app360">
                <line x1="600"
                      x2="600"
                      y1="1200"
@@ -2693,7 +2693,7 @@
          <!--LinkInfo VALUE: C08_app392_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app392">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app392">
                <line x1="600"
                      x2="600"
                      y1="1230"
@@ -2756,7 +2756,7 @@
          <!--LinkInfo VALUE: C08_app394_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app394">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app394">
                <line x1="600"
                      x2="600"
                      y1="1260"
@@ -2819,7 +2819,7 @@
          <!--LinkInfo VALUE: C08_app408_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app408">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app408">
                <line x1="600"
                      x2="600"
                      y1="1290"
@@ -2882,7 +2882,7 @@
          <!--LinkInfo VALUE: C08_app410_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app410">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app410">
                <line x1="600"
                      x2="600"
                      y1="1320"
@@ -2945,7 +2945,7 @@
          <!--LinkInfo VALUE: C08_app425_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app425">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app425">
                <line x1="600"
                      x2="600"
                      y1="1350"
@@ -3019,7 +3019,7 @@
          <!--LinkInfo VALUE: C08_app431_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app431">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app431">
                <line x1="600"
                      x2="600"
                      y1="1380"
@@ -3082,7 +3082,7 @@
          <!--LinkInfo VALUE: C08_app444_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app444">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app444">
                <line x1="600"
                      x2="600"
                      y1="1410"
@@ -3156,7 +3156,7 @@
          <!--LinkInfo VALUE: C08_app462_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app462">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_i/#C08_app462">
                <line x1="600"
                      x2="600"
                      y1="1440"
@@ -3230,7 +3230,7 @@
          <!--LinkInfo VALUE: C08_app528_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app528">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app528">
                <line x1="600"
                      x2="600"
                      y1="1470"
@@ -3304,7 +3304,7 @@
          <!--LinkInfo VALUE: C08_app547_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app547">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app547">
                <line x1="600"
                      x2="600"
                      y1="1500"
@@ -3378,7 +3378,7 @@
          <!--LinkInfo VALUE: C08_app634_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app634">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app634">
                <line x1="600"
                      x2="600"
                      y1="1530"
@@ -3452,7 +3452,7 @@
          <!--LinkInfo VALUE: C08_app646_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app646">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app646">
                <line x1="600"
                      x2="600"
                      y1="1560"
@@ -3515,7 +3515,7 @@
          <!--LinkInfo VALUE: C08_app662_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app662">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app662">
                <line x1="600"
                      x2="600"
                      y1="1590"
@@ -3589,7 +3589,7 @@
          <!--LinkInfo VALUE: C08_app681_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app681">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app681">
                <line x1="600"
                      x2="600"
                      y1="1620"
@@ -3663,7 +3663,7 @@
          <!--LinkInfo VALUE: C08_app683_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app683">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app683">
                <line x1="600"
                      x2="600"
                      y1="1650"
@@ -3726,7 +3726,7 @@
          <!--LinkInfo VALUE: C08_app684_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app684">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app684">
                <line x1="600"
                      x2="600"
                      y1="1680"
@@ -3800,7 +3800,7 @@
          <!--LinkInfo VALUE: C08_app700_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app700">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app700">
                <line x1="600"
                      x2="600"
                      y1="1710"
@@ -3874,7 +3874,7 @@
          <!--LinkInfo VALUE: C08_app702_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app702">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app702">
                <line x1="600"
                      x2="600"
                      y1="1740"
@@ -3948,7 +3948,7 @@
          <!--LinkInfo VALUE: C08_app724_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app724">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app724">
                <line x1="600"
                      x2="600"
                      y1="1770"
@@ -4022,7 +4022,7 @@
          <!--LinkInfo VALUE: C08_app787_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app787">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app787">
                <line x1="600"
                      x2="600"
                      y1="1800"
@@ -4096,7 +4096,7 @@
          <!--LinkInfo VALUE: C08_app794_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app794">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app794">
                <line x1="600"
                      x2="600"
                      y1="1830"
@@ -4170,7 +4170,7 @@
          <!--LinkInfo VALUE: C08_app891_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app891">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app891">
                <line x1="600"
                      x2="600"
                      y1="1860"
@@ -4244,7 +4244,7 @@
          <!--LinkInfo VALUE: C08_app902_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app902">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app902">
                <line x1="600"
                      x2="600"
                      y1="1890"
@@ -4318,7 +4318,7 @@
          <!--LinkInfo VALUE: C08_app928_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app928">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app928">
                <line x1="600"
                      x2="600"
                      y1="1920"
@@ -4392,7 +4392,7 @@
          <!--LinkInfo VALUE: C08_app1057_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app1057">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app1057">
                <line x1="600"
                      x2="600"
                      y1="1950"
@@ -4466,7 +4466,7 @@
          <!--LinkInfo VALUE: C08_app1064_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app1064">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app1064">
                <line x1="600"
                      x2="600"
                      y1="1980"
@@ -4540,7 +4540,7 @@
          <!--LinkInfo VALUE: C08_app1107_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app1107">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app1107">
                <line x1="600"
                      x2="600"
                      y1="2010"
@@ -4614,7 +4614,7 @@
          <!--LinkInfo VALUE: C08_app1167_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app1167">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app1167">
                <line x1="600"
                      x2="600"
                      y1="2040"
@@ -4688,7 +4688,7 @@
          <!--LinkInfo VALUE: C08_app1195_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_ii/#C08_app1195">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_ii/#C08_app1195">
                <line x1="600"
                      x2="600"
                      y1="2070"
@@ -4762,7 +4762,7 @@
          <!--LinkInfo VALUE: C09_app37_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iii/#C09_app37">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iii/#C09_app37">
                <line x1="600"
                      x2="600"
                      y1="2100"
@@ -4836,7 +4836,7 @@
          <!--LinkInfo VALUE: C09_app141_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iii/#C09_app141">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iii/#C09_app141">
                <line x1="600"
                      x2="600"
                      y1="2130"
@@ -4910,7 +4910,7 @@
          <!--LinkInfo VALUE: C09_app177_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iii/#C09_app177">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iii/#C09_app177">
                <line x1="600"
                      x2="600"
                      y1="2160"
@@ -4984,7 +4984,7 @@
          <!--LinkInfo VALUE: C09_app329_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iii/#C09_app329">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iii/#C09_app329">
                <line x1="600"
                      x2="600"
                      y1="2190"
@@ -5058,7 +5058,7 @@
          <!--LinkInfo VALUE: C09_app403_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iii/#C09_app403">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iii/#C09_app403">
                <line x1="600"
                      x2="600"
                      y1="2220"
@@ -5132,7 +5132,7 @@
          <!--LinkInfo VALUE: C09_app410_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iii/#C09_app410">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iii/#C09_app410">
                <line x1="600"
                      x2="600"
                      y1="2250"
@@ -5206,7 +5206,7 @@
          <!--LinkInfo VALUE: C09_app744_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iii/#C09_app744">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iii/#C09_app744">
                <line x1="600"
                      x2="600"
                      y1="2280"
@@ -5280,7 +5280,7 @@
          <!--LinkInfo VALUE: C09_app751_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iii/#C09_app751">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iii/#C09_app751">
                <line x1="600"
                      x2="600"
                      y1="2310"
@@ -5354,7 +5354,7 @@
          <!--LinkInfo VALUE: C10_app59_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iv/#C10_app59">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iv/#C10_app59">
                <line x1="600"
                      x2="600"
                      y1="2340"
@@ -5428,7 +5428,7 @@
          <!--LinkInfo VALUE: C10_app359_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iv/#C10_app359">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iv/#C10_app359">
                <line x1="600"
                      x2="600"
                      y1="2370"
@@ -5502,7 +5502,7 @@
          <!--LinkInfo VALUE: C10_app384_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_iv/#C10_app384">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_iv/#C10_app384">
                <line x1="600"
                      x2="600"
                      y1="2400"
@@ -5576,7 +5576,7 @@
          <!--LinkInfo VALUE: C11_app4_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app4">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app4">
                <line x1="600"
                      x2="600"
                      y1="2430"
@@ -5639,7 +5639,7 @@
          <!--LinkInfo VALUE: C11_app14_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app14">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app14">
                <line x1="600"
                      x2="600"
                      y1="2460"
@@ -5776,7 +5776,7 @@
          <!--LinkInfo VALUE: C11_app49_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app49">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app49">
                <line x1="600"
                      x2="600"
                      y1="2520"
@@ -5850,7 +5850,7 @@
          <!--LinkInfo VALUE: C11_app64_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app64">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app64">
                <line x1="600"
                      x2="600"
                      y1="2550"
@@ -5924,7 +5924,7 @@
          <!--LinkInfo VALUE: C11_app100_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app100">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app100">
                <line x1="600"
                      x2="600"
                      y1="2580"
@@ -5998,7 +5998,7 @@
          <!--LinkInfo VALUE: C11_app108_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app108">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app108">
                <line x1="600"
                      x2="600"
                      y1="2610"
@@ -6072,7 +6072,7 @@
          <!--LinkInfo VALUE: C11_app244_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app244">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app244">
                <line x1="600"
                      x2="600"
                      y1="2640"
@@ -6146,7 +6146,7 @@
          <!--LinkInfo VALUE: C11_app313_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app313">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app313">
                <line x1="600"
                      x2="600"
                      y1="2670"
@@ -6220,7 +6220,7 @@
          <!--LinkInfo VALUE: C11_app427_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app427">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app427">
                <line x1="600"
                      x2="600"
                      y1="2700"
@@ -6294,7 +6294,7 @@
          <!--LinkInfo VALUE: C11_app485_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app485">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app485">
                <line x1="600"
                      x2="600"
                      y1="2730"
@@ -6357,7 +6357,7 @@
          <!--LinkInfo VALUE: C11_app502_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C11_app502">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app502">
                <line x1="600"
                      x2="600"
                      y1="2760"
@@ -6420,7 +6420,7 @@
          <!--LinkInfo VALUE: C12_app217_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C12_app217">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C12_app217">
                <line x1="600"
                      x2="600"
                      y1="2790"
@@ -6494,7 +6494,7 @@
          <!--LinkInfo VALUE: C12_app220_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_v/#C12_app220">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C12_app220">
                <line x1="600"
                      x2="600"
                      y1="2820"
@@ -6631,7 +6631,7 @@
          <!--LinkInfo VALUE: C13_app305_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app305">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app305">
                <line x1="600"
                      x2="600"
                      y1="2880"
@@ -6705,7 +6705,7 @@
          <!--LinkInfo VALUE: C13_app320_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app320">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app320">
                <line x1="600"
                      x2="600"
                      y1="2910"
@@ -6779,7 +6779,7 @@
          <!--LinkInfo VALUE: C13_app322_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app322">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app322">
                <line x1="600"
                      x2="600"
                      y1="2940"
@@ -6853,7 +6853,7 @@
          <!--LinkInfo VALUE: C13_app540_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app540">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app540">
                <line x1="600"
                      x2="600"
                      y1="2970"
@@ -6927,7 +6927,7 @@
          <!--LinkInfo VALUE: C13_app550_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app550">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app550">
                <line x1="600"
                      x2="600"
                      y1="3000"
@@ -7001,7 +7001,7 @@
          <!--LinkInfo VALUE: C13_app580_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app580">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app580">
                <line x1="600"
                      x2="600"
                      y1="3030"
@@ -7075,7 +7075,7 @@
          <!--LinkInfo VALUE: C13_app651_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app651">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app651">
                <line x1="600"
                      x2="600"
                      y1="3060"
@@ -7149,7 +7149,7 @@
          <!--LinkInfo VALUE: C13_app773_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app773">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app773">
                <line x1="600"
                      x2="600"
                      y1="3090"
@@ -7223,7 +7223,7 @@
          <!--LinkInfo VALUE: C13_app775_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app775">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app775">
                <line x1="600"
                      x2="600"
                      y1="3120"
@@ -7297,7 +7297,7 @@
          <!--LinkInfo VALUE: C13_app797_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app797">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app797">
                <line x1="600"
                      x2="600"
                      y1="3150"
@@ -7371,7 +7371,7 @@
          <!--LinkInfo VALUE: C13_app868_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app868">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app868">
                <line x1="600"
                      x2="600"
                      y1="3180"
@@ -7434,7 +7434,7 @@
          <!--LinkInfo VALUE: C13_app875_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app875">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app875">
                <line x1="600"
                      x2="600"
                      y1="3210"
@@ -7497,7 +7497,7 @@
          <!--LinkInfo VALUE: C13_app885_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app885">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app885">
                <line x1="600"
                      x2="600"
                      y1="3240"
@@ -7571,7 +7571,7 @@
          <!--LinkInfo VALUE: C13_app907_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app907">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app907">
                <line x1="600"
                      x2="600"
                      y1="3270"
@@ -7645,7 +7645,7 @@
          <!--LinkInfo VALUE: C13_app965_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app965">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app965">
                <line x1="600"
                      x2="600"
                      y1="3300"
@@ -7719,7 +7719,7 @@
          <!--LinkInfo VALUE: C13_app1017_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app1017">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app1017">
                <line x1="600"
                      x2="600"
                      y1="3330"
@@ -7793,7 +7793,7 @@
          <!--LinkInfo VALUE: C13_app1058_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app1058">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app1058">
                <line x1="600"
                      x2="600"
                      y1="3360"
@@ -7867,7 +7867,7 @@
          <!--LinkInfo VALUE: C13_app1064_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app1064">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app1064">
                <line x1="600"
                      x2="600"
                      y1="3390"
@@ -7930,7 +7930,7 @@
          <!--LinkInfo VALUE: C13_app1088_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app1088">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app1088">
                <line x1="600"
                      x2="600"
                      y1="3420"
@@ -8004,7 +8004,7 @@
          <!--LinkInfo VALUE: C13_app1172_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vi/#C13_app1172">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vi/#C13_app1172">
                <line x1="600"
                      x2="600"
                      y1="3450"
@@ -8078,7 +8078,7 @@
          <!--LinkInfo VALUE: C14_app215_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app215">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app215">
                <line x1="600"
                      x2="600"
                      y1="3480"
@@ -8152,7 +8152,7 @@
          <!--LinkInfo VALUE: C14_app250_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app250">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app250">
                <line x1="600"
                      x2="600"
                      y1="3510"
@@ -8226,7 +8226,7 @@
          <!--LinkInfo VALUE: C14_app251_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app251">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app251">
                <line x1="600"
                      x2="600"
                      y1="3540"
@@ -8300,7 +8300,7 @@
          <!--LinkInfo VALUE: C14_app551_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app551">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app551">
                <line x1="600"
                      x2="600"
                      y1="3570"
@@ -8374,7 +8374,7 @@
          <!--LinkInfo VALUE: C14_app754_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app754">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app754">
                <line x1="600"
                      x2="600"
                      y1="3600"
@@ -8437,7 +8437,7 @@
          <!--LinkInfo VALUE: C14_app815_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app815">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app815">
                <line x1="600"
                      x2="600"
                      y1="3630"
@@ -8511,7 +8511,7 @@
          <!--LinkInfo VALUE: C14_app836_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app836">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app836">
                <line x1="600"
                      x2="600"
                      y1="3660"
@@ -8585,7 +8585,7 @@
          <!--LinkInfo VALUE: C14_app975_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app975">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app975">
                <line x1="600"
                      x2="600"
                      y1="3690"
@@ -8659,7 +8659,7 @@
          <!--LinkInfo VALUE: C14_app993_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app993">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app993">
                <line x1="600"
                      x2="600"
                      y1="3720"
@@ -8733,7 +8733,7 @@
          <!--LinkInfo VALUE: C14_app1016_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app1016">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app1016">
                <line x1="600"
                      x2="600"
                      y1="3750"
@@ -8807,7 +8807,7 @@
          <!--LinkInfo VALUE: C14_app1018_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app1018">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app1018">
                <line x1="600"
                      x2="600"
                      y1="3780"
@@ -8870,7 +8870,7 @@
          <!--LinkInfo VALUE: C14_app1032_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_1_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_vii/#C14_app1032">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_vii/#C14_app1032">
                <line x1="600"
                      x2="600"
                      y1="3810"
@@ -8944,7 +8944,7 @@
          <!--LinkInfo VALUE: C15_app32_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app32">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app32">
                <line x1="600"
                      x2="600"
                      y1="3840"
@@ -9018,7 +9018,7 @@
          <!--LinkInfo VALUE: C15_app75_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app75">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app75">
                <line x1="600"
                      x2="600"
                      y1="3870"
@@ -9092,7 +9092,7 @@
          <!--LinkInfo VALUE: C15_app109_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app109">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app109">
                <line x1="600"
                      x2="600"
                      y1="3900"
@@ -9229,7 +9229,7 @@
          <!--LinkInfo VALUE: C15_app326_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app326">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app326">
                <line x1="600"
                      x2="600"
                      y1="3960"
@@ -9303,7 +9303,7 @@
          <!--LinkInfo VALUE: C15_app441_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app441">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app441">
                <line x1="600"
                      x2="600"
                      y1="3990"
@@ -9366,7 +9366,7 @@
          <!--LinkInfo VALUE: C15_app442_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app442">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app442">
                <line x1="600"
                      x2="600"
                      y1="4020"
@@ -9440,7 +9440,7 @@
          <!--LinkInfo VALUE: C15_app449_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app449">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app449">
                <line x1="600"
                      x2="600"
                      y1="4050"
@@ -9514,7 +9514,7 @@
          <!--LinkInfo VALUE: C15_app460_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app460">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app460">
                <line x1="600"
                      x2="600"
                      y1="4080"
@@ -9588,7 +9588,7 @@
          <!--LinkInfo VALUE: C15_app497_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app497">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app497">
                <line x1="600"
                      x2="600"
                      y1="4110"
@@ -9651,7 +9651,7 @@
          <!--LinkInfo VALUE: C15_app520_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app520">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app520">
                <line x1="600"
                      x2="600"
                      y1="4140"
@@ -9714,7 +9714,7 @@
          <!--LinkInfo VALUE: C15_app523_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app523">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app523">
                <line x1="600"
                      x2="600"
                      y1="4170"
@@ -9788,7 +9788,7 @@
          <!--LinkInfo VALUE: C15_app545_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app545">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app545">
                <line x1="600"
                      x2="600"
                      y1="4200"
@@ -9862,7 +9862,7 @@
          <!--LinkInfo VALUE: C15_app576_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app576">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app576">
                <line x1="600"
                      x2="600"
                      y1="4230"
@@ -9936,7 +9936,7 @@
          <!--LinkInfo VALUE: C15_app624_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app624">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app624">
                <line x1="600"
                      x2="600"
                      y1="4260"
@@ -10010,7 +10010,7 @@
          <!--LinkInfo VALUE: C15_app679_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app679">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app679">
                <line x1="600"
                      x2="600"
                      y1="4290"
@@ -10084,7 +10084,7 @@
          <!--LinkInfo VALUE: C15_app692_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_i/#C15_app692">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_i/#C15_app692">
                <line x1="600"
                      x2="600"
                      y1="4320"
@@ -10158,7 +10158,7 @@
          <!--LinkInfo VALUE: C16_app6_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_ii/#C16_app6">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_ii/#C16_app6">
                <line x1="600"
                      x2="600"
                      y1="4350"
@@ -10232,7 +10232,7 @@
          <!--LinkInfo VALUE: C16_app36_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_ii/#C16_app36">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_ii/#C16_app36">
                <line x1="600"
                      x2="600"
                      y1="4380"
@@ -10295,7 +10295,7 @@
          <!--LinkInfo VALUE: C16_app49_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_ii/#C16_app49">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_ii/#C16_app49">
                <line x1="600"
                      x2="600"
                      y1="4410"
@@ -10369,7 +10369,7 @@
          <!--LinkInfo VALUE: C16_app60_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_ii/#C16_app60">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_ii/#C16_app60">
                <line x1="600"
                      x2="600"
                      y1="4440"
@@ -10443,7 +10443,7 @@
          <!--LinkInfo VALUE: C16_app292_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_ii/#C16_app292">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_ii/#C16_app292">
                <line x1="600"
                      x2="600"
                      y1="4470"
@@ -10517,7 +10517,7 @@
          <!--LinkInfo VALUE: C16_app387_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_ii/#C16_app387">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_ii/#C16_app387">
                <line x1="600"
                      x2="600"
                      y1="4500"
@@ -10591,7 +10591,7 @@
          <!--LinkInfo VALUE: C17_app479_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_iii/#C17_app479">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_iii/#C17_app479">
                <line x1="600"
                      x2="600"
                      y1="4530"
@@ -10665,7 +10665,7 @@
          <!--LinkInfo VALUE: C17_app586_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_iii/#C17_app586">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_iii/#C17_app586">
                <line x1="600"
                      x2="600"
                      y1="4560"
@@ -10739,7 +10739,7 @@
          <!--LinkInfo VALUE: C17_app602_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_iii/#C17_app602">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_iii/#C17_app602">
                <line x1="600"
                      x2="600"
                      y1="4590"
@@ -10813,7 +10813,7 @@
          <!--LinkInfo VALUE: C17_app809_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_iii/#C17_app809">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_iii/#C17_app809">
                <line x1="600"
                      x2="600"
                      y1="4620"
@@ -10876,7 +10876,7 @@
          <!--LinkInfo VALUE: C17_app1095_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_iii/#C17_app1095">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_iii/#C17_app1095">
                <line x1="600"
                      x2="600"
                      y1="4650"
@@ -10950,7 +10950,7 @@
          <!--LinkInfo VALUE: C18_app148_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_iv/#C18_app148">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_iv/#C18_app148">
                <line x1="600"
                      x2="600"
                      y1="4680"
@@ -11024,7 +11024,7 @@
          <!--LinkInfo VALUE: C18_app156_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_iv/#C18_app156">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_iv/#C18_app156">
                <line x1="600"
                      x2="600"
                      y1="4710"
@@ -11098,7 +11098,7 @@
          <!--LinkInfo VALUE: C18_app481_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_iv/#C18_app481">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_iv/#C18_app481">
                <line x1="600"
                      x2="600"
                      y1="4740"
@@ -11161,7 +11161,7 @@
          <!--LinkInfo VALUE: C19_app23_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_v/#C19_app23">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_v/#C19_app23">
                <line x1="600"
                      x2="600"
                      y1="4770"
@@ -11235,7 +11235,7 @@
          <!--LinkInfo VALUE: C20_app170_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_vi/#C20_app170">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_vi/#C20_app170">
                <line x1="600"
                      x2="600"
                      y1="4800"
@@ -11309,7 +11309,7 @@
          <!--LinkInfo VALUE: C20_app200_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_vi/#C20_app200">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_vi/#C20_app200">
                <line x1="600"
                      x2="600"
                      y1="4830"
@@ -11383,7 +11383,7 @@
          <!--LinkInfo VALUE: C20_app277_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_vi/#C20_app277">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_vi/#C20_app277">
                <line x1="600"
                      x2="600"
                      y1="4860"
@@ -11457,7 +11457,7 @@
          <!--LinkInfo VALUE: C21_app351_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_vii/#C21_app351">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_vii/#C21_app351">
                <line x1="600"
                      x2="600"
                      y1="4890"
@@ -11531,7 +11531,7 @@
          <!--LinkInfo VALUE: C21_app458_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_vii/#C21_app458">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_vii/#C21_app458">
                <line x1="600"
                      x2="600"
                      y1="4920"
@@ -11605,7 +11605,7 @@
          <!--LinkInfo VALUE: C21_app538_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_vii/#C21_app538">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_vii/#C21_app538">
                <line x1="600"
                      x2="600"
                      y1="4950"
@@ -11679,7 +11679,7 @@
          <!--LinkInfo VALUE: C21_app1034_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_vii/#C21_app1034">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_vii/#C21_app1034">
                <line x1="600"
                      x2="600"
                      y1="4980"
@@ -11753,7 +11753,7 @@
          <!--LinkInfo VALUE: C21_app1095_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_vii/#C21_app1095">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_vii/#C21_app1095">
                <line x1="600"
                      x2="600"
                      y1="5010"
@@ -11827,7 +11827,7 @@
          <!--LinkInfo VALUE: C22_app311_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_viii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_viii/#C22_app311">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_viii/#C22_app311">
                <line x1="600"
                      x2="600"
                      y1="5040"
@@ -11901,7 +11901,7 @@
          <!--LinkInfo VALUE: C22_app619_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_viii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_viii/#C22_app619">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_viii/#C22_app619">
                <line x1="600"
                      x2="600"
                      y1="5070"
@@ -11975,7 +11975,7 @@
          <!--LinkInfo VALUE: C22_app641_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_viii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_viii/#C22_app641">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_viii/#C22_app641">
                <line x1="600"
                      x2="600"
                      y1="5100"
@@ -12049,7 +12049,7 @@
          <!--LinkInfo VALUE: C22_app718_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_viii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_viii/#C22_app718">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_viii/#C22_app718">
                <line x1="600"
                      x2="600"
                      y1="5130"
@@ -12123,7 +12123,7 @@
          <!--LinkInfo VALUE: C22_app783_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_viii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_viii/#C22_app783">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_viii/#C22_app783">
                <line x1="600"
                      x2="600"
                      y1="5160"
@@ -12197,7 +12197,7 @@
          <!--LinkInfo VALUE: C22_app994_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_viii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_viii/#C22_app994">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_viii/#C22_app994">
                <line x1="600"
                      x2="600"
                      y1="5190"
@@ -12271,7 +12271,7 @@
          <!--LinkInfo VALUE: C23_app568_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_ix-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_ix/#C23_app568">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_ix/#C23_app568">
                <line x1="600"
                      x2="600"
                      y1="5220"
@@ -12334,7 +12334,7 @@
          <!--LinkInfo VALUE: C23_app575_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_2_chapter_ix-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_2_chapter_ix/#C23_app575">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_2_chapter_ix/#C23_app575">
                <line x1="600"
                      x2="600"
                      y1="5250"
@@ -12408,7 +12408,7 @@
          <!--LinkInfo VALUE: C24_app15_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app15">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app15">
                <line x1="600"
                      x2="600"
                      y1="5280"
@@ -12482,7 +12482,7 @@
          <!--LinkInfo VALUE: C24_app70_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app70">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app70">
                <line x1="600"
                      x2="600"
                      y1="5310"
@@ -12556,7 +12556,7 @@
          <!--LinkInfo VALUE: C24_app82_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app82">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app82">
                <line x1="600"
                      x2="600"
                      y1="5340"
@@ -12630,7 +12630,7 @@
          <!--LinkInfo VALUE: C24_app180_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app180">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app180">
                <line x1="600"
                      x2="600"
                      y1="5370"
@@ -12704,7 +12704,7 @@
          <!--LinkInfo VALUE: C24_app224_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app224">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app224">
                <line x1="600"
                      x2="600"
                      y1="5400"
@@ -12778,7 +12778,7 @@
          <!--LinkInfo VALUE: C24_app329_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app329">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app329">
                <line x1="600"
                      x2="600"
                      y1="5430"
@@ -12841,7 +12841,7 @@
          <!--LinkInfo VALUE: C24_app330_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app330">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app330">
                <line x1="600"
                      x2="600"
                      y1="5460"
@@ -12904,7 +12904,7 @@
          <!--LinkInfo VALUE: C24_app332_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app332">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app332">
                <line x1="600"
                      x2="600"
                      y1="5490"
@@ -12978,7 +12978,7 @@
          <!--LinkInfo VALUE: C24_app562_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C24_app562">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C24_app562">
                <line x1="600"
                      x2="600"
                      y1="5520"
@@ -13052,7 +13052,7 @@
          <!--LinkInfo VALUE: C25_app8_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_i-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_i/#C25_app8">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_i/#C25_app8">
                <line x1="600"
                      x2="600"
                      y1="5550"
@@ -13126,7 +13126,7 @@
          <!--LinkInfo VALUE: C25_app111_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app111">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app111">
                <line x1="600"
                      x2="600"
                      y1="5580"
@@ -13200,7 +13200,7 @@
          <!--LinkInfo VALUE: C25_app217_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app217">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app217">
                <line x1="600"
                      x2="600"
                      y1="5610"
@@ -13274,7 +13274,7 @@
          <!--LinkInfo VALUE: C25_app245_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app245">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app245">
                <line x1="600"
                      x2="600"
                      y1="5640"
@@ -13348,7 +13348,7 @@
          <!--LinkInfo VALUE: C25_app261_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app261">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app261">
                <line x1="600"
                      x2="600"
                      y1="5670"
@@ -13422,7 +13422,7 @@
          <!--LinkInfo VALUE: C25_app266_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app266">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app266">
                <line x1="600"
                      x2="600"
                      y1="5700"
@@ -13496,7 +13496,7 @@
          <!--LinkInfo VALUE: C25_app278_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app278">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app278">
                <line x1="600"
                      x2="600"
                      y1="5730"
@@ -13570,7 +13570,7 @@
          <!--LinkInfo VALUE: C25_app291_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app291">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app291">
                <line x1="600"
                      x2="600"
                      y1="5760"
@@ -13644,7 +13644,7 @@
          <!--LinkInfo VALUE: C25_app293_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app293">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app293">
                <line x1="600"
                      x2="600"
                      y1="5790"
@@ -13718,7 +13718,7 @@
          <!--LinkInfo VALUE: C25_app299_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app299">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app299">
                <line x1="600"
                      x2="600"
                      y1="5820"
@@ -13792,7 +13792,7 @@
          <!--LinkInfo VALUE: C25_app311_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app311">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app311">
                <line x1="600"
                      x2="600"
                      y1="5850"
@@ -13866,7 +13866,7 @@
          <!--LinkInfo VALUE: C25_app313_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app313">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app313">
                <line x1="600"
                      x2="600"
                      y1="5880"
@@ -13940,7 +13940,7 @@
          <!--LinkInfo VALUE: C25_app509_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app509">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app509">
                <line x1="600"
                      x2="600"
                      y1="5910"
@@ -14014,7 +14014,7 @@
          <!--LinkInfo VALUE: C25_app780_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_ii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_ii/#C25_app780">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_ii/#C25_app780">
                <line x1="600"
                      x2="600"
                      y1="5940"
@@ -14088,7 +14088,7 @@
          <!--LinkInfo VALUE: C26_app80_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iii/#C26_app80">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iii/#C26_app80">
                <line x1="600"
                      x2="600"
                      y1="5970"
@@ -14162,7 +14162,7 @@
          <!--LinkInfo VALUE: C26_app82_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iii/#C26_app82">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iii/#C26_app82">
                <line x1="600"
                      x2="600"
                      y1="6000"
@@ -14236,7 +14236,7 @@
          <!--LinkInfo VALUE: C26_app547_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iii/#C26_app547">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iii/#C26_app547">
                <line x1="600"
                      x2="600"
                      y1="6030"
@@ -14310,7 +14310,7 @@
          <!--LinkInfo VALUE: C26_app549_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iii/#C26_app549">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iii/#C26_app549">
                <line x1="600"
                      x2="600"
                      y1="6060"
@@ -14384,7 +14384,7 @@
          <!--LinkInfo VALUE: C26_app796_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iii/#C26_app796">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iii/#C26_app796">
                <line x1="600"
                      x2="600"
                      y1="6090"
@@ -14458,7 +14458,7 @@
          <!--LinkInfo VALUE: C27_app419_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iv/#C27_app419">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iv/#C27_app419">
                <line x1="600"
                      x2="600"
                      y1="6120"
@@ -14532,7 +14532,7 @@
          <!--LinkInfo VALUE: C27_app539_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iv/#C27_app539">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iv/#C27_app539">
                <line x1="600"
                      x2="600"
                      y1="6150"
@@ -14606,7 +14606,7 @@
          <!--LinkInfo VALUE: C27_app627_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iv/#C27_app627">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iv/#C27_app627">
                <line x1="600"
                      x2="600"
                      y1="6180"
@@ -14680,7 +14680,7 @@
          <!--LinkInfo VALUE: C27_app760_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iv/#C27_app760">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iv/#C27_app760">
                <line x1="600"
                      x2="600"
                      y1="6210"
@@ -14754,7 +14754,7 @@
          <!--LinkInfo VALUE: C27_app947_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iv/#C27_app947">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iv/#C27_app947">
                <line x1="600"
                      x2="600"
                      y1="6240"
@@ -14828,7 +14828,7 @@
          <!--LinkInfo VALUE: C27_app969_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iv/#C27_app969">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iv/#C27_app969">
                <line x1="600"
                      x2="600"
                      y1="6270"
@@ -14902,7 +14902,7 @@
          <!--LinkInfo VALUE: C27_app1130_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_iv-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_iv/#C27_app1130">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_iv/#C27_app1130">
                <line x1="600"
                      x2="600"
                      y1="6300"
@@ -14965,7 +14965,7 @@
          <!--LinkInfo VALUE: C28_app16_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C28_app16">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C28_app16">
                <line x1="600"
                      x2="600"
                      y1="6330"
@@ -15039,7 +15039,7 @@
          <!--LinkInfo VALUE: C28_app38_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C28_app38">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C28_app38">
                <line x1="600"
                      x2="600"
                      y1="6360"
@@ -15102,7 +15102,7 @@
          <!--LinkInfo VALUE: C28_app40_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C28_app40">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C28_app40">
                <line x1="600"
                      x2="600"
                      y1="6390"
@@ -15176,7 +15176,7 @@
          <!--LinkInfo VALUE: C28_app48_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C28_app48">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C28_app48">
                <line x1="600"
                      x2="600"
                      y1="6420"
@@ -15250,7 +15250,7 @@
          <!--LinkInfo VALUE: C28_app112_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C28_app112">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C28_app112">
                <line x1="600"
                      x2="600"
                      y1="6450"
@@ -15324,7 +15324,7 @@
          <!--LinkInfo VALUE: C28_app114_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C28_app114">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C28_app114">
                <line x1="600"
                      x2="600"
                      y1="6480"
@@ -15398,7 +15398,7 @@
          <!--LinkInfo VALUE: C28_app151_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C28_app151">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C28_app151">
                <line x1="600"
                      x2="600"
                      y1="6510"
@@ -15472,7 +15472,7 @@
          <!--LinkInfo VALUE: C28_app185_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C28_app185">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C28_app185">
                <line x1="600"
                      x2="600"
                      y1="6540"
@@ -15546,7 +15546,7 @@
          <!--LinkInfo VALUE: C29_app292_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C29_app292">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C29_app292">
                <line x1="600"
                      x2="600"
                      y1="6570"
@@ -15620,7 +15620,7 @@
          <!--LinkInfo VALUE: C29_app542_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C29_app542">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C29_app542">
                <line x1="600"
                      x2="600"
                      y1="6600"
@@ -15694,7 +15694,7 @@
          <!--LinkInfo VALUE: C29_app609_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C29_app609">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C29_app609">
                <line x1="600"
                      x2="600"
                      y1="6630"
@@ -15768,7 +15768,7 @@
          <!--LinkInfo VALUE: C29_app721_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_v-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_v/#C29_app721">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_v/#C29_app721">
                <line x1="600"
                      x2="600"
                      y1="6660"
@@ -15842,7 +15842,7 @@
          <!--LinkInfo VALUE: C30_app4_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vi/#C30_app4">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vi/#C30_app4">
                <line x1="600"
                      x2="600"
                      y1="6690"
@@ -15916,7 +15916,7 @@
          <!--LinkInfo VALUE: C30_app57_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vi/#C30_app57">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vi/#C30_app57">
                <line x1="600"
                      x2="600"
                      y1="6720"
@@ -15990,7 +15990,7 @@
          <!--LinkInfo VALUE: C30_app63_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vi/#C30_app63">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vi/#C30_app63">
                <line x1="600"
                      x2="600"
                      y1="6750"
@@ -16064,7 +16064,7 @@
          <!--LinkInfo VALUE: C30_app304_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vi/#C30_app304">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vi/#C30_app304">
                <line x1="600"
                      x2="600"
                      y1="6780"
@@ -16138,7 +16138,7 @@
          <!--LinkInfo VALUE: C30_app329_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vi/#C30_app329">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vi/#C30_app329">
                <line x1="600"
                      x2="600"
                      y1="6810"
@@ -16212,7 +16212,7 @@
          <!--LinkInfo VALUE: C30_app331_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vi/#C30_app331">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vi/#C30_app331">
                <line x1="600"
                      x2="600"
                      y1="6840"
@@ -16286,7 +16286,7 @@
          <!--LinkInfo VALUE: C30_app495_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vi/#C30_app495">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vi/#C30_app495">
                <line x1="600"
                      x2="600"
                      y1="6870"
@@ -16360,7 +16360,7 @@
          <!--LinkInfo VALUE: C30_app695_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vi-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vi/#C30_app695">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vi/#C30_app695">
                <line x1="600"
                      x2="600"
                      y1="6900"
@@ -16434,7 +16434,7 @@
          <!--LinkInfo VALUE: C31_app800_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C31_app800">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C31_app800">
                <line x1="600"
                      x2="600"
                      y1="6930"
@@ -16508,7 +16508,7 @@
          <!--LinkInfo VALUE: C31_app971_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C31_app971">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C31_app971">
                <line x1="600"
                      x2="600"
                      y1="6960"
@@ -16582,7 +16582,7 @@
          <!--LinkInfo VALUE: C31_app1057_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C31_app1057">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C31_app1057">
                <line x1="600"
                      x2="600"
                      y1="6990"
@@ -16656,7 +16656,7 @@
          <!--LinkInfo VALUE: C33_app35_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app35">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app35">
                <line x1="600"
                      x2="600"
                      y1="7020"
@@ -16730,7 +16730,7 @@
          <!--LinkInfo VALUE: C33_app653_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app653">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app653">
                <line x1="600"
                      x2="600"
                      y1="7050"
@@ -16804,7 +16804,7 @@
          <!--LinkInfo VALUE: C33_app749_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app749">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app749">
                <line x1="600"
                      x2="600"
                      y1="7080"
@@ -16878,7 +16878,7 @@
          <!--LinkInfo VALUE: C33_app804_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app804">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app804">
                <line x1="600"
                      x2="600"
                      y1="7110"
@@ -16952,7 +16952,7 @@
          <!--LinkInfo VALUE: C33_app818_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app818">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app818">
                <line x1="600"
                      x2="600"
                      y1="7140"
@@ -17026,7 +17026,7 @@
          <!--LinkInfo VALUE: C33_app836_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app836">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app836">
                <line x1="600"
                      x2="600"
                      y1="7170"
@@ -17100,7 +17100,7 @@
          <!--LinkInfo VALUE: C33_app879_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app879">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app879">
                <line x1="600"
                      x2="600"
                      y1="7200"
@@ -17174,7 +17174,7 @@
          <!--LinkInfo VALUE: C33_app946_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app946">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app946">
                <line x1="600"
                      x2="600"
                      y1="7230"
@@ -17248,7 +17248,7 @@
          <!--LinkInfo VALUE: C33_app964_rg1-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app964">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app964">
                <line x1="600"
                      x2="600"
                      y1="7260"
@@ -17322,7 +17322,7 @@
          <!--LinkInfo VALUE: C33_app1208_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app1208">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app1208">
                <line x1="600"
                      x2="600"
                      y1="7290"
@@ -17396,7 +17396,7 @@
          <!--LinkInfo VALUE: C33_app1230_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app1230">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app1230">
                <line x1="600"
                      x2="600"
                      y1="7320"
@@ -17470,7 +17470,7 @@
          <!--LinkInfo VALUE: C33_app1240_rg2-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app1240">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app1240">
                <line x1="600"
                      x2="600"
                      y1="7350"
@@ -17544,7 +17544,7 @@
          <!--LinkInfo VALUE: C33_app1337_rg3-->
          <!--fThomas SPINE CHAPTER LOCATION: fThomas_vol_3_chapter_vii-->
          <g class="fThomas">
-            <a xlink:href="https://frankensteinvariorum.org/viewer/Thas/vol_3_chapter_vii/#C33_app1337">
+            <a xlink:href="https://frankensteinvariorum.org/viewer/Thomas/vol_3_chapter_vii/#C33_app1337">
                <line x1="600"
                      x2="600"
                      y1="7380"

--- a/postColl-workspace/edit-distance/svgPrepData-to-SVG.xsl
+++ b/postColl-workspace/edit-distance/svgPrepData-to-SVG.xsl
@@ -59,7 +59,8 @@
             <xsl:comment><xsl:value-of select="$currentWit"/> SPINE CHAPTER LOCATION: <xsl:value-of select="$chapterLocation"/></xsl:comment>
             
             
-            <xsl:variable name="linkConstructor" as="xs:string" select="'https://frankensteinvariorum.org/viewer/'||$chapterLocation ! tokenize(., '_') ! substring-after(., 'f') ! translate(., 'rom', '')||'/'||$chapterLocation ! substring-after(., '_')||'/#'||$linkInfo ! substring-before(., '_rg')"/>
+<!--            <xsl:variable name="linkConstructor" as="xs:string" select="'https://frankensteinvariorum.org/viewer/'||$chapterLocation ! tokenize(., '_') ! substring-after(., 'f') ! translate(., 'rom', '')||'/'||$chapterLocation ! substring-after(., '_')||'/#'||$linkInfo ! substring-before(., '_rg')"/>-->
+            <xsl:variable name="linkConstructor" as="xs:string" select="'https://frankensteinvariorum.org/viewer/'||$chapterLocation ! tokenize(., '_')[1] ! substring-after(., 'f')||'/'||$chapterLocation ! substring-after(., '_')||'/#'||$linkInfo ! substring-before(., '_rg')"/>
             <!-- SAMPLE LINK TO FV: https://frankensteinvariorum.org/viewer/1818/vol_3_chapter_i/#C24_app15 -->
               
             <g class="{current()}">

--- a/postColl-workspace/edit-distance/svgPrepData-to-SVG.xsl
+++ b/postColl-workspace/edit-distance/svgPrepData-to-SVG.xsl
@@ -59,8 +59,8 @@
             <xsl:comment><xsl:value-of select="$currentWit"/> SPINE CHAPTER LOCATION: <xsl:value-of select="$chapterLocation"/></xsl:comment>
             
             
-<!--            <xsl:variable name="linkConstructor" as="xs:string" select="'https://frankensteinvariorum.org/viewer/'||$chapterLocation ! tokenize(., '_') ! substring-after(., 'f') ! translate(., 'rom', '')||'/'||$chapterLocation ! substring-after(., '_')||'/#'||$linkInfo ! substring-before(., '_rg')"/>-->
-            <xsl:variable name="linkConstructor" as="xs:string" select="'https://frankensteinvariorum.org/viewer/'||$chapterLocation ! tokenize(., '_')[1] ! substring-after(., 'f')||'/'||$chapterLocation ! substring-after(., '_')||'/#'||$linkInfo ! substring-before(., '_rg')"/>
+            <xsl:variable name="linkConstructor" as="xs:string" select="'https://frankensteinvariorum.org/viewer/'||$chapterLocation ! tokenize(., '_')[1] ! substring-after(., 'f') ! replace(., '(rom)', '')||'/'||$chapterLocation ! substring-after(., '_')||'/#'||$linkInfo ! substring-before(., '_rg')"/>
+         
             <!-- SAMPLE LINK TO FV: https://frankensteinvariorum.org/viewer/1818/vol_3_chapter_i/#C24_app15 -->
               
             <g class="{current()}">


### PR DESCRIPTION
The original xslt file would genereate the Thomas link `https://frankensteinvariorum.org/viewer/Thas/vol_1_chapter_i/#C08_app211`, which is wrong. 
The current one can generate the correct link for Thomas edition like `https://frankensteinvariorum.org/viewer/Thomas/vol_1_chapter_v/#C11_app49`.